### PR TITLE
feat(frontend): Implement Recommendations UI and Global Search (Issue #17)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/Krol-X/NiceMusicLibrary/issues/17
+Your prepared branch: issue-17-259ed23d697f
+Your prepared working directory: /tmp/gh-issue-solver-1766940259364
+Your forked repository: konard/Krol-X-NiceMusicLibrary
+Original repository (upstream): Krol-X/NiceMusicLibrary
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/Krol-X/NiceMusicLibrary/issues/17
-Your prepared branch: issue-17-259ed23d697f
-Your prepared working directory: /tmp/gh-issue-solver-1766940259364
-Your forked repository: konard/Krol-X-NiceMusicLibrary
-Original repository (upstream): Krol-X/NiceMusicLibrary
-
-Proceed.

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue'
 import { RouterView, useRoute } from 'vue-router'
 import { AppLayout, AuthLayout } from '@/components/layout'
+import { GlobalSearch } from '@/components/search'
 import { useKeyboard } from '@/composables'
 
 // Initialize global keyboard shortcuts
@@ -16,4 +17,6 @@ const isAuthLayout = computed(() => route.meta?.layout === 'auth')
   <component :is="isAuthLayout ? AuthLayout : AppLayout">
     <RouterView />
   </component>
+  <!-- Global search modal (rendered via Teleport) -->
+  <GlobalSearch />
 </template>

--- a/frontend/src/__tests__/App.spec.ts
+++ b/frontend/src/__tests__/App.spec.ts
@@ -37,6 +37,13 @@ const mockRoute = ref({
 
 vi.mock('vue-router', () => ({
   useRoute: () => mockRoute.value,
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    go: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+  }),
   RouterView: { template: '<div class="router-view"></div>' },
 }))
 
@@ -54,6 +61,7 @@ describe('App', () => {
           RouterView: true,
           AppLayout: true,
           AuthLayout: true,
+          GlobalSearch: true,
         },
       },
     })
@@ -72,6 +80,7 @@ describe('App', () => {
           AuthLayout: {
             template: '<div class="auth-layout"><slot /></div>',
           },
+          GlobalSearch: true,
         },
       },
     })
@@ -91,6 +100,7 @@ describe('App', () => {
           AuthLayout: {
             template: '<div class="auth-layout"><slot /></div>',
           },
+          GlobalSearch: true,
         },
       },
     })

--- a/frontend/src/__tests__/stores/recommendations.spec.ts
+++ b/frontend/src/__tests__/stores/recommendations.spec.ts
@@ -1,0 +1,504 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { useRecommendationsStore } from '../../stores/recommendations'
+import * as recommendationsService from '../../services/recommendations'
+import type {
+  Song,
+  DiscoverResponse,
+  SimilarSongsResponse,
+  PersonalMixResponse,
+  SearchResponse,
+} from '../../types'
+
+// Mock the recommendations service
+vi.mock('../../services/recommendations', () => ({
+  recommendationsService: {
+    getDiscover: vi.fn(),
+    getSimilarSongs: vi.fn(),
+    getPersonalMix: vi.fn(),
+    search: vi.fn(),
+  },
+}))
+
+const mockSong: Song = {
+  id: '123e4567-e89b-12d3-a456-426614174000',
+  title: 'Test Song',
+  artist: 'Test Artist',
+  album: 'Test Album',
+  genre: 'Rock',
+  year: 2023,
+  duration_seconds: 180,
+  file_format: 'mp3',
+  play_count: 10,
+  last_played_at: null,
+  is_favorite: false,
+  rating: null,
+  cover_art_path: null,
+  created_at: '2023-01-01T00:00:00Z',
+}
+
+const mockSong2: Song = {
+  ...mockSong,
+  id: '223e4567-e89b-12d3-a456-426614174001',
+  title: 'Another Song',
+}
+
+const mockDiscoverResponse: DiscoverResponse = {
+  sections: [
+    {
+      type: 'long_time_no_listen',
+      title: 'Давно не слушали',
+      items: [mockSong],
+    },
+    {
+      type: 'based_on_favorite',
+      title: 'На основе любимого',
+      items: [mockSong2],
+    },
+    {
+      type: 'hidden_gems',
+      title: 'Скрытые жемчужины',
+      items: [],
+    },
+  ],
+}
+
+const mockSimilarSongsResponse: SimilarSongsResponse = {
+  source_song: mockSong,
+  items: [
+    {
+      song: mockSong2,
+      similarity_score: 0.85,
+      reasons: ['Same genre', 'Similar BPM'],
+    },
+  ],
+}
+
+const mockPersonalMixResponse: PersonalMixResponse = {
+  songs: [mockSong, mockSong2],
+  total_duration_seconds: 360,
+  mood: 'energetic',
+}
+
+const mockSearchResponse: SearchResponse = {
+  query: 'test',
+  songs: [mockSong],
+  artists: [
+    {
+      name: 'Test Artist',
+      song_count: 5,
+      songs: [mockSong],
+    },
+  ],
+  albums: [
+    {
+      name: 'Test Album',
+      artist: 'Test Artist',
+      song_count: 10,
+      songs: [mockSong],
+    },
+  ],
+  playlists: [],
+}
+
+describe('recommendationsStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('initial state', () => {
+    it('has correct default values', () => {
+      const store = useRecommendationsStore()
+
+      expect(store.discoverSections).toEqual([])
+      expect(store.isLoadingDiscover).toBe(false)
+      expect(store.discoverError).toBe(null)
+      expect(store.similarSongsMap).toEqual({})
+      expect(store.loadingSimilarFor).toBe(null)
+      expect(store.personalMixSongs).toEqual([])
+      expect(store.personalMixDuration).toBe(0)
+      expect(store.personalMixMood).toBe(null)
+      expect(store.searchQuery).toBe('')
+      expect(store.searchResults).toBe(null)
+      expect(store.isSearching).toBe(false)
+    })
+  })
+
+  describe('getters', () => {
+    it('hasDiscoverSections returns false when empty', () => {
+      const store = useRecommendationsStore()
+      expect(store.hasDiscoverSections).toBe(false)
+    })
+
+    it('hasDiscoverSections returns true when sections exist', () => {
+      const store = useRecommendationsStore()
+      store.discoverSections = mockDiscoverResponse.sections
+      expect(store.hasDiscoverSections).toBe(true)
+    })
+
+    it('longTimeNoListen returns correct section items', () => {
+      const store = useRecommendationsStore()
+      store.discoverSections = mockDiscoverResponse.sections
+
+      expect(store.longTimeNoListen).toEqual([mockSong])
+    })
+
+    it('basedOnFavorite returns correct section items', () => {
+      const store = useRecommendationsStore()
+      store.discoverSections = mockDiscoverResponse.sections
+
+      expect(store.basedOnFavorite).toEqual([mockSong2])
+    })
+
+    it('hiddenGems returns empty array when section is empty', () => {
+      const store = useRecommendationsStore()
+      store.discoverSections = mockDiscoverResponse.sections
+
+      expect(store.hiddenGems).toEqual([])
+    })
+
+    it('isLoading returns true when any loading state is active', () => {
+      const store = useRecommendationsStore()
+
+      expect(store.isLoading).toBe(false)
+
+      store.isLoadingDiscover = true
+      expect(store.isLoading).toBe(true)
+
+      store.isLoadingDiscover = false
+      store.loadingSimilarFor = 'some-id'
+      expect(store.isLoading).toBe(true)
+
+      store.loadingSimilarFor = null
+      store.isLoadingMix = true
+      expect(store.isLoading).toBe(true)
+
+      store.isLoadingMix = false
+      store.isSearching = true
+      expect(store.isLoading).toBe(true)
+    })
+  })
+
+  describe('fetchDiscover', () => {
+    it('fetches discover recommendations and updates state', async () => {
+      const store = useRecommendationsStore()
+      vi.mocked(
+        recommendationsService.recommendationsService.getDiscover
+      ).mockResolvedValue(mockDiscoverResponse)
+
+      await store.fetchDiscover()
+
+      expect(
+        recommendationsService.recommendationsService.getDiscover
+      ).toHaveBeenCalledWith(10)
+      expect(store.discoverSections).toEqual(mockDiscoverResponse.sections)
+      expect(store.isLoadingDiscover).toBe(false)
+    })
+
+    it('sets isLoadingDiscover during fetch', async () => {
+      const store = useRecommendationsStore()
+      let loadingDuringFetch = false
+
+      vi.mocked(
+        recommendationsService.recommendationsService.getDiscover
+      ).mockImplementation(async () => {
+        loadingDuringFetch = store.isLoadingDiscover
+        return mockDiscoverResponse
+      })
+
+      await store.fetchDiscover()
+
+      expect(loadingDuringFetch).toBe(true)
+    })
+
+    it('handles fetch error', async () => {
+      const store = useRecommendationsStore()
+      vi.mocked(
+        recommendationsService.recommendationsService.getDiscover
+      ).mockRejectedValue(new Error('Network error'))
+
+      await expect(store.fetchDiscover()).rejects.toThrow('Network error')
+      expect(store.discoverError).toBe('Network error')
+      expect(store.isLoadingDiscover).toBe(false)
+    })
+  })
+
+  describe('fetchSimilar', () => {
+    it('fetches similar songs and caches result', async () => {
+      const store = useRecommendationsStore()
+      vi.mocked(
+        recommendationsService.recommendationsService.getSimilarSongs
+      ).mockResolvedValue(mockSimilarSongsResponse)
+
+      const result = await store.fetchSimilar(mockSong.id)
+
+      expect(
+        recommendationsService.recommendationsService.getSimilarSongs
+      ).toHaveBeenCalledWith(mockSong.id, 10)
+      expect(result).toEqual(mockSimilarSongsResponse.items)
+      expect(store.similarSongsMap[mockSong.id]).toEqual(
+        mockSimilarSongsResponse.items
+      )
+    })
+
+    it('returns cached result without fetching', async () => {
+      const store = useRecommendationsStore()
+      store.similarSongsMap[mockSong.id] = mockSimilarSongsResponse.items
+
+      const result = await store.fetchSimilar(mockSong.id)
+
+      expect(
+        recommendationsService.recommendationsService.getSimilarSongs
+      ).not.toHaveBeenCalled()
+      expect(result).toEqual(mockSimilarSongsResponse.items)
+    })
+
+    it('sets loadingSimilarFor during fetch', async () => {
+      const store = useRecommendationsStore()
+      let loadingSongId: string | null = null
+
+      vi.mocked(
+        recommendationsService.recommendationsService.getSimilarSongs
+      ).mockImplementation(async () => {
+        loadingSongId = store.loadingSimilarFor
+        return mockSimilarSongsResponse
+      })
+
+      await store.fetchSimilar(mockSong.id)
+
+      expect(loadingSongId).toBe(mockSong.id)
+      expect(store.loadingSimilarFor).toBe(null)
+    })
+  })
+
+  describe('getSimilarSongs', () => {
+    it('returns cached similar songs', () => {
+      const store = useRecommendationsStore()
+      store.similarSongsMap[mockSong.id] = mockSimilarSongsResponse.items
+
+      expect(store.getSimilarSongs(mockSong.id)).toEqual(
+        mockSimilarSongsResponse.items
+      )
+    })
+
+    it('returns empty array when no cache', () => {
+      const store = useRecommendationsStore()
+
+      expect(store.getSimilarSongs(mockSong.id)).toEqual([])
+    })
+  })
+
+  describe('isLoadingSimilar', () => {
+    it('returns true when loading for specific song', () => {
+      const store = useRecommendationsStore()
+      store.loadingSimilarFor = mockSong.id
+
+      expect(store.isLoadingSimilar(mockSong.id)).toBe(true)
+      expect(store.isLoadingSimilar('other-id')).toBe(false)
+    })
+  })
+
+  describe('generateMix', () => {
+    it('generates personal mix and updates state', async () => {
+      const store = useRecommendationsStore()
+      vi.mocked(
+        recommendationsService.recommendationsService.getPersonalMix
+      ).mockResolvedValue(mockPersonalMixResponse)
+
+      const result = await store.generateMix({ mood: 'energetic', duration_minutes: 60 })
+
+      expect(
+        recommendationsService.recommendationsService.getPersonalMix
+      ).toHaveBeenCalledWith({ mood: 'energetic', duration_minutes: 60 })
+      expect(result).toEqual(mockPersonalMixResponse.songs)
+      expect(store.personalMixSongs).toEqual(mockPersonalMixResponse.songs)
+      expect(store.personalMixDuration).toBe(360)
+      expect(store.personalMixMood).toBe('energetic')
+    })
+
+    it('sets isLoadingMix during generation', async () => {
+      const store = useRecommendationsStore()
+      let loadingDuringGen = false
+
+      vi.mocked(
+        recommendationsService.recommendationsService.getPersonalMix
+      ).mockImplementation(async () => {
+        loadingDuringGen = store.isLoadingMix
+        return mockPersonalMixResponse
+      })
+
+      await store.generateMix()
+
+      expect(loadingDuringGen).toBe(true)
+      expect(store.isLoadingMix).toBe(false)
+    })
+
+    it('handles generation error', async () => {
+      const store = useRecommendationsStore()
+      vi.mocked(
+        recommendationsService.recommendationsService.getPersonalMix
+      ).mockRejectedValue(new Error('Generation failed'))
+
+      await expect(store.generateMix()).rejects.toThrow('Generation failed')
+      expect(store.mixError).toBe('Generation failed')
+    })
+  })
+
+  describe('search', () => {
+    it('performs search and updates state', async () => {
+      const store = useRecommendationsStore()
+      vi.mocked(
+        recommendationsService.recommendationsService.search
+      ).mockResolvedValue(mockSearchResponse)
+
+      const result = await store.search('test')
+
+      expect(recommendationsService.recommendationsService.search).toHaveBeenCalledWith(
+        'test',
+        'all',
+        10
+      )
+      expect(result).toEqual(mockSearchResponse)
+      expect(store.searchQuery).toBe('test')
+      expect(store.searchResults).toEqual(mockSearchResponse)
+    })
+
+    it('returns empty results for empty query', async () => {
+      const store = useRecommendationsStore()
+
+      const result = await store.search('   ')
+
+      expect(recommendationsService.recommendationsService.search).not.toHaveBeenCalled()
+      expect(result).toEqual({
+        query: '',
+        songs: [],
+        artists: [],
+        albums: [],
+        playlists: [],
+      })
+    })
+
+    it('sets isSearching during search', async () => {
+      const store = useRecommendationsStore()
+      let searchingDuringSearch = false
+
+      vi.mocked(
+        recommendationsService.recommendationsService.search
+      ).mockImplementation(async () => {
+        searchingDuringSearch = store.isSearching
+        return mockSearchResponse
+      })
+
+      await store.search('test')
+
+      expect(searchingDuringSearch).toBe(true)
+      expect(store.isSearching).toBe(false)
+    })
+
+    it('handles search error', async () => {
+      const store = useRecommendationsStore()
+      vi.mocked(recommendationsService.recommendationsService.search).mockRejectedValue(
+        new Error('Search failed')
+      )
+
+      await expect(store.search('test')).rejects.toThrow('Search failed')
+      expect(store.searchError).toBe('Search failed')
+    })
+  })
+
+  describe('clearSearch', () => {
+    it('clears search state', () => {
+      const store = useRecommendationsStore()
+      store.searchQuery = 'test'
+      store.searchResults = mockSearchResponse
+      store.searchError = 'error'
+
+      store.clearSearch()
+
+      expect(store.searchQuery).toBe('')
+      expect(store.searchResults).toBe(null)
+      expect(store.searchError).toBe(null)
+    })
+  })
+
+  describe('clearMix', () => {
+    it('clears personal mix state', () => {
+      const store = useRecommendationsStore()
+      store.personalMixSongs = [mockSong]
+      store.personalMixDuration = 180
+      store.personalMixMood = 'calm'
+
+      store.clearMix()
+
+      expect(store.personalMixSongs).toEqual([])
+      expect(store.personalMixDuration).toBe(0)
+      expect(store.personalMixMood).toBe(null)
+    })
+  })
+
+  describe('clearSimilarCache', () => {
+    it('clears specific song cache', () => {
+      const store = useRecommendationsStore()
+      store.similarSongsMap[mockSong.id] = mockSimilarSongsResponse.items
+      store.similarSongsMap[mockSong2.id] = mockSimilarSongsResponse.items
+
+      store.clearSimilarCache(mockSong.id)
+
+      expect(store.similarSongsMap[mockSong.id]).toBeUndefined()
+      expect(store.similarSongsMap[mockSong2.id]).toEqual(
+        mockSimilarSongsResponse.items
+      )
+    })
+
+    it('clears all cache when no songId provided', () => {
+      const store = useRecommendationsStore()
+      store.similarSongsMap[mockSong.id] = mockSimilarSongsResponse.items
+      store.similarSongsMap[mockSong2.id] = mockSimilarSongsResponse.items
+
+      store.clearSimilarCache()
+
+      expect(store.similarSongsMap).toEqual({})
+    })
+  })
+
+  describe('clearErrors', () => {
+    it('clears all error states', () => {
+      const store = useRecommendationsStore()
+      store.discoverError = 'discover error'
+      store.similarError = 'similar error'
+      store.mixError = 'mix error'
+      store.searchError = 'search error'
+
+      store.clearErrors()
+
+      expect(store.discoverError).toBe(null)
+      expect(store.similarError).toBe(null)
+      expect(store.mixError).toBe(null)
+      expect(store.searchError).toBe(null)
+    })
+  })
+
+  describe('reset', () => {
+    it('resets store to initial state', () => {
+      const store = useRecommendationsStore()
+      store.discoverSections = mockDiscoverResponse.sections
+      store.similarSongsMap[mockSong.id] = mockSimilarSongsResponse.items
+      store.personalMixSongs = [mockSong]
+      store.searchQuery = 'test'
+      store.discoverError = 'error'
+
+      store.reset()
+
+      expect(store.discoverSections).toEqual([])
+      expect(store.similarSongsMap).toEqual({})
+      expect(store.personalMixSongs).toEqual([])
+      expect(store.searchQuery).toBe('')
+      expect(store.discoverError).toBe(null)
+    })
+  })
+})

--- a/frontend/src/components/recommendations/PersonalMixCard.vue
+++ b/frontend/src/components/recommendations/PersonalMixCard.vue
@@ -1,0 +1,244 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useRecommendationsStore } from '@/stores/recommendations'
+import { usePlayerStore } from '@/stores/player'
+import type { Song, MoodType } from '@/types'
+import { Loader, Button, Modal } from '@/components/ui'
+import { formatDuration } from '@/services/songs'
+
+const recommendationsStore = useRecommendationsStore()
+const playerStore = usePlayerStore()
+
+const { personalMixSongs, personalMixDuration, personalMixMood, isLoadingMix, mixError } =
+  storeToRefs(recommendationsStore)
+
+const isSettingsOpen = ref(false)
+const selectedMood = ref<MoodType | undefined>(undefined)
+const selectedDuration = ref(60)
+
+const hasActiveMix = computed(() => personalMixSongs.value.length > 0)
+const formattedDuration = computed(() => formatDuration(personalMixDuration.value))
+const songCount = computed(() => personalMixSongs.value.length)
+
+const moodLabel = computed(() => {
+  if (!personalMixMood.value) return 'Any mood'
+  const labels: Record<MoodType, string> = {
+    energetic: 'Energetic',
+    calm: 'Calm',
+    focus: 'Focus',
+  }
+  return labels[personalMixMood.value]
+})
+
+async function generateMix() {
+  isSettingsOpen.value = false
+  await recommendationsStore.generateMix({
+    mood: selectedMood.value,
+    duration_minutes: selectedDuration.value,
+  })
+}
+
+function playMix() {
+  if (personalMixSongs.value.length > 0) {
+    playerStore.setQueue(personalMixSongs.value as Song[])
+    playerStore.play()
+  }
+}
+
+function openSettings() {
+  // Initialize with current settings if available
+  selectedMood.value = personalMixMood.value ?? undefined
+  selectedDuration.value = Math.round(personalMixDuration.value / 60) || 60
+  isSettingsOpen.value = true
+}
+
+function setMood(mood: MoodType | undefined) {
+  selectedMood.value = mood
+}
+</script>
+
+<template>
+  <div class="card">
+    <div class="flex items-start gap-4">
+      <!-- Mix icon -->
+      <div class="flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-accent-primary to-accent-secondary">
+        <svg
+          class="h-8 w-8 text-white"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          stroke-width="1.5"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456zM16.894 20.567L16.5 21.75l-.394-1.183a2.25 2.25 0 00-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 001.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 001.423 1.423l1.183.394-1.183.394a2.25 2.25 0 00-1.423 1.423z"
+          />
+        </svg>
+      </div>
+
+      <!-- Content -->
+      <div class="flex-1 min-w-0">
+        <h3 class="text-h3 text-text-primary mb-1">Personal Mix</h3>
+
+        <template v-if="isLoadingMix">
+          <div class="flex items-center gap-2">
+            <Loader size="sm" />
+            <span class="text-small text-text-secondary">Generating your mix...</span>
+          </div>
+        </template>
+
+        <template v-else-if="mixError">
+          <p class="text-small text-accent-error">{{ mixError }}</p>
+        </template>
+
+        <template v-else-if="hasActiveMix">
+          <p class="text-small text-text-secondary mb-2">
+            {{ songCount }} songs · {{ formattedDuration }} · {{ moodLabel }}
+          </p>
+          <div class="flex gap-2">
+            <Button
+              variant="primary"
+              size="sm"
+              @click="playMix"
+            >
+              <svg
+                class="h-4 w-4 mr-1"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M4.5 5.653c0-1.426 1.529-2.33 2.779-1.643l11.54 6.348c1.295.712 1.295 2.573 0 3.285L7.28 19.991c-1.25.687-2.779-.217-2.779-1.643V5.653z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+              Play Mix
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              @click="openSettings"
+            >
+              New Mix
+            </Button>
+          </div>
+        </template>
+
+        <template v-else>
+          <p class="text-small text-text-secondary mb-2">
+            Generate a personalized mix based on your taste
+          </p>
+          <Button
+            variant="primary"
+            size="sm"
+            @click="openSettings"
+          >
+            Create Mix
+          </Button>
+        </template>
+      </div>
+    </div>
+
+    <!-- Settings Modal -->
+    <Modal
+      v-model="isSettingsOpen"
+      title="Mix Settings"
+      size="sm"
+    >
+      <div class="space-y-4">
+        <!-- Mood selection -->
+        <div>
+          <label class="block text-small font-medium text-text-primary mb-2">Mood</label>
+          <div class="flex flex-wrap gap-2">
+            <button
+              type="button"
+              :class="[
+                'rounded-full px-4 py-2 text-small font-medium transition-colors',
+                selectedMood === undefined
+                  ? 'bg-accent-primary text-white'
+                  : 'bg-bg-secondary text-text-secondary hover:bg-bg-tertiary',
+              ]"
+              @click="setMood(undefined)"
+            >
+              Any
+            </button>
+            <button
+              type="button"
+              :class="[
+                'rounded-full px-4 py-2 text-small font-medium transition-colors',
+                selectedMood === 'energetic'
+                  ? 'bg-accent-primary text-white'
+                  : 'bg-bg-secondary text-text-secondary hover:bg-bg-tertiary',
+              ]"
+              @click="setMood('energetic')"
+            >
+              Energetic
+            </button>
+            <button
+              type="button"
+              :class="[
+                'rounded-full px-4 py-2 text-small font-medium transition-colors',
+                selectedMood === 'calm'
+                  ? 'bg-accent-primary text-white'
+                  : 'bg-bg-secondary text-text-secondary hover:bg-bg-tertiary',
+              ]"
+              @click="setMood('calm')"
+            >
+              Calm
+            </button>
+            <button
+              type="button"
+              :class="[
+                'rounded-full px-4 py-2 text-small font-medium transition-colors',
+                selectedMood === 'focus'
+                  ? 'bg-accent-primary text-white'
+                  : 'bg-bg-secondary text-text-secondary hover:bg-bg-tertiary',
+              ]"
+              @click="setMood('focus')"
+            >
+              Focus
+            </button>
+          </div>
+        </div>
+
+        <!-- Duration slider -->
+        <div>
+          <label class="block text-small font-medium text-text-primary mb-2">
+            Duration: {{ selectedDuration }} minutes
+          </label>
+          <input
+            v-model.number="selectedDuration"
+            type="range"
+            min="15"
+            max="180"
+            step="15"
+            class="w-full accent-accent-primary"
+          >
+          <div class="flex justify-between text-caption text-text-muted mt-1">
+            <span>15 min</span>
+            <span>3 hours</span>
+          </div>
+        </div>
+      </div>
+
+      <template #footer>
+        <Button
+          variant="secondary"
+          @click="isSettingsOpen = false"
+        >
+          Cancel
+        </Button>
+        <Button
+          variant="primary"
+          @click="generateMix"
+        >
+          Generate Mix
+        </Button>
+      </template>
+    </Modal>
+  </div>
+</template>

--- a/frontend/src/components/recommendations/RecommendationCard.vue
+++ b/frontend/src/components/recommendations/RecommendationCard.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { Song } from '@/types'
+import { formatDuration, getCoverUrl } from '@/services/songs'
+
+export interface RecommendationCardProps {
+  song: Song
+  isPlaying?: boolean
+  showReason?: boolean
+  reason?: string
+}
+
+const props = withDefaults(defineProps<RecommendationCardProps>(), {
+  isPlaying: false,
+  showReason: false,
+  reason: undefined,
+})
+
+const emit = defineEmits<{
+  click: [song: Song]
+  play: [song: Song]
+}>()
+
+const duration = computed(() => formatDuration(props.song.duration_seconds))
+const coverUrl = computed(() =>
+  props.song.cover_art_path ? getCoverUrl(props.song.id) : null
+)
+
+function handleClick() {
+  emit('click', props.song)
+}
+
+function handlePlay(event: MouseEvent) {
+  event.stopPropagation()
+  emit('play', props.song)
+}
+</script>
+
+<template>
+  <div
+    :class="[
+      'group relative cursor-pointer rounded-lg p-3 transition-all duration-fast',
+      'bg-bg-secondary hover:bg-bg-tertiary hover:shadow-md',
+      'w-40 flex-shrink-0',
+    ]"
+    @click="handleClick"
+  >
+    <!-- Cover art -->
+    <div class="relative mb-3 aspect-square overflow-hidden rounded-md bg-bg-tertiary">
+      <img
+        v-if="coverUrl"
+        :src="coverUrl"
+        :alt="song.title"
+        class="h-full w-full object-cover transition-transform duration-normal group-hover:scale-105"
+        loading="lazy"
+      >
+      <div
+        v-else
+        class="flex h-full w-full items-center justify-center"
+      >
+        <svg
+          class="h-10 w-10 text-text-muted"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          stroke-width="1"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M9 9l10.5-3m0 6.553v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 11-.99-3.467l2.31-.66a2.25 2.25 0 001.632-2.163zm0 0V2.25L9 5.25v10.303m0 0v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 01-.99-3.467l2.31-.66A2.25 2.25 0 009 15.553z"
+          />
+        </svg>
+      </div>
+
+      <!-- Play button overlay -->
+      <div
+        class="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity duration-fast group-hover:opacity-100"
+      >
+        <button
+          type="button"
+          class="flex h-10 w-10 items-center justify-center rounded-full bg-accent-primary text-white shadow-lg transition-transform hover:scale-110"
+          aria-label="Play"
+          @click="handlePlay"
+        >
+          <svg
+            class="h-5 w-5 translate-x-0.5"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M4.5 5.653c0-1.426 1.529-2.33 2.779-1.643l11.54 6.348c1.295.712 1.295 2.573 0 3.285L7.28 19.991c-1.25.687-2.779-.217-2.779-1.643V5.653z"
+              clip-rule="evenodd"
+            />
+          </svg>
+        </button>
+      </div>
+
+      <!-- Playing indicator -->
+      <div
+        v-if="isPlaying"
+        class="absolute bottom-2 right-2 flex items-center gap-0.5 rounded bg-accent-primary px-1.5 py-0.5"
+      >
+        <span class="inline-block h-2 w-0.5 animate-pulse bg-white" />
+        <span class="inline-block h-3 w-0.5 animate-pulse bg-white" style="animation-delay: 150ms" />
+        <span class="inline-block h-2 w-0.5 animate-pulse bg-white" style="animation-delay: 300ms" />
+      </div>
+    </div>
+
+    <!-- Info -->
+    <div class="min-w-0">
+      <p
+        :class="[
+          'truncate text-small font-medium',
+          isPlaying ? 'text-accent-primary' : 'text-text-primary',
+        ]"
+        :title="song.title"
+      >
+        {{ song.title }}
+      </p>
+      <p
+        class="truncate text-caption text-text-secondary"
+        :title="song.artist || 'Unknown Artist'"
+      >
+        {{ song.artist || 'Unknown Artist' }}
+      </p>
+      <p
+        v-if="showReason && reason"
+        class="mt-1 truncate text-caption text-text-muted"
+        :title="reason"
+      >
+        {{ reason }}
+      </p>
+      <p
+        v-else
+        class="mt-1 text-caption text-text-muted"
+      >
+        {{ duration }}
+      </p>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/recommendations/RecommendationSection.vue
+++ b/frontend/src/components/recommendations/RecommendationSection.vue
@@ -1,0 +1,151 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import type { Song } from '@/types'
+import RecommendationCard from './RecommendationCard.vue'
+import { Loader } from '@/components/ui'
+
+export interface RecommendationSectionProps {
+  title: string
+  songs: Song[]
+  isLoading?: boolean
+  showReason?: boolean
+  reasons?: Record<string, string>
+  currentSongId?: string | null
+}
+
+const props = withDefaults(defineProps<RecommendationSectionProps>(), {
+  isLoading: false,
+  showReason: false,
+  reasons: () => ({}),
+  currentSongId: null,
+})
+
+const emit = defineEmits<{
+  playSong: [song: Song]
+  clickSong: [song: Song]
+}>()
+
+const scrollContainer = ref<HTMLElement | null>(null)
+const canScrollLeft = ref(false)
+const canScrollRight = ref(true)
+
+const isEmpty = computed(() => props.songs.length === 0 && !props.isLoading)
+
+function updateScrollButtons() {
+  if (!scrollContainer.value) return
+  const { scrollLeft, scrollWidth, clientWidth } = scrollContainer.value
+  canScrollLeft.value = scrollLeft > 0
+  canScrollRight.value = scrollLeft + clientWidth < scrollWidth - 10
+}
+
+function scrollLeft() {
+  if (!scrollContainer.value) return
+  scrollContainer.value.scrollBy({ left: -300, behavior: 'smooth' })
+}
+
+function scrollRight() {
+  if (!scrollContainer.value) return
+  scrollContainer.value.scrollBy({ left: 300, behavior: 'smooth' })
+}
+
+function handlePlay(song: Song) {
+  emit('playSong', song)
+}
+
+function handleClick(song: Song) {
+  emit('clickSong', song)
+}
+</script>
+
+<template>
+  <section class="mb-6">
+    <!-- Section header -->
+    <div class="mb-3 flex items-center justify-between">
+      <h2 class="text-h3 text-text-primary">{{ title }}</h2>
+      <div
+        v-if="songs.length > 4"
+        class="flex gap-1"
+      >
+        <button
+          type="button"
+          :disabled="!canScrollLeft"
+          class="rounded-full p-1.5 text-text-secondary transition-colors hover:bg-bg-secondary hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-30"
+          aria-label="Scroll left"
+          @click="scrollLeft"
+        >
+          <svg
+            class="h-5 w-5"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M15.75 19.5L8.25 12l7.5-7.5"
+            />
+          </svg>
+        </button>
+        <button
+          type="button"
+          :disabled="!canScrollRight"
+          class="rounded-full p-1.5 text-text-secondary transition-colors hover:bg-bg-secondary hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-30"
+          aria-label="Scroll right"
+          @click="scrollRight"
+        >
+          <svg
+            class="h-5 w-5"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M8.25 4.5l7.5 7.5-7.5 7.5"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+
+    <!-- Loading state -->
+    <div
+      v-if="isLoading"
+      class="flex h-48 items-center justify-center"
+    >
+      <Loader size="lg" />
+    </div>
+
+    <!-- Empty state -->
+    <div
+      v-else-if="isEmpty"
+      class="flex h-48 items-center justify-center rounded-lg border border-dashed border-bg-tertiary"
+    >
+      <p class="text-text-muted">No songs in this section</p>
+    </div>
+
+    <!-- Songs scroll container -->
+    <div
+      v-else
+      ref="scrollContainer"
+      class="flex gap-3 overflow-x-auto pb-2 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-bg-tertiary"
+      @scroll="updateScrollButtons"
+    >
+      <RecommendationCard
+        v-for="song in songs"
+        :key="song.id"
+        :song="song"
+        :is-playing="currentSongId === song.id"
+        :show-reason="showReason"
+        :reason="reasons[song.id]"
+        @play="handlePlay"
+        @click="handleClick"
+      />
+    </div>
+  </section>
+</template>

--- a/frontend/src/components/recommendations/SimilarSongs.vue
+++ b/frontend/src/components/recommendations/SimilarSongs.vue
@@ -1,0 +1,120 @@
+<script setup lang="ts">
+import { onMounted, computed } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useRecommendationsStore } from '@/stores/recommendations'
+import type { Song } from '@/types'
+import RecommendationCard from './RecommendationCard.vue'
+import { Loader } from '@/components/ui'
+
+export interface SimilarSongsProps {
+  songId: string
+  currentSongId?: string | null
+}
+
+const props = withDefaults(defineProps<SimilarSongsProps>(), {
+  currentSongId: null,
+})
+
+const emit = defineEmits<{
+  playSong: [song: Song]
+  clickSong: [song: Song]
+}>()
+
+const recommendationsStore = useRecommendationsStore()
+const { similarError } = storeToRefs(recommendationsStore)
+
+const isLoading = computed(() => recommendationsStore.isLoadingSimilar(props.songId))
+const similarItems = computed(() => recommendationsStore.getSimilarSongs(props.songId))
+const isEmpty = computed(() => similarItems.value.length === 0 && !isLoading.value)
+
+// Create a map of song ID to reason for display
+const reasonsMap = computed(() => {
+  const map: Record<string, string> = {}
+  for (const item of similarItems.value) {
+    if (item.reasons.length > 0) {
+      map[item.song.id] = item.reasons[0]
+    }
+  }
+  return map
+})
+
+const songs = computed(() => similarItems.value.map((item) => item.song))
+
+onMounted(async () => {
+  if (similarItems.value.length === 0) {
+    await recommendationsStore.fetchSimilar(props.songId)
+  }
+})
+
+function handlePlay(song: Song) {
+  emit('playSong', song)
+}
+
+function handleClick(song: Song) {
+  emit('clickSong', song)
+}
+</script>
+
+<template>
+  <section class="mb-6">
+    <!-- Section header -->
+    <div class="mb-3 flex items-center gap-2">
+      <svg
+        class="h-5 w-5 text-text-secondary"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        stroke-width="1.5"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M9 9l10.5-3m0 6.553v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 11-.99-3.467l2.31-.66a2.25 2.25 0 001.632-2.163zm0 0V2.25L9 5.25v10.303m0 0v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 01-.99-3.467l2.31-.66A2.25 2.25 0 009 15.553z"
+        />
+      </svg>
+      <h2 class="text-h3 text-text-primary">Similar Songs</h2>
+    </div>
+
+    <!-- Loading state -->
+    <div
+      v-if="isLoading"
+      class="flex h-32 items-center justify-center"
+    >
+      <Loader size="md" />
+    </div>
+
+    <!-- Error state -->
+    <div
+      v-else-if="similarError"
+      class="flex h-32 items-center justify-center rounded-lg border border-dashed border-accent-error/30"
+    >
+      <p class="text-text-muted">{{ similarError }}</p>
+    </div>
+
+    <!-- Empty state -->
+    <div
+      v-else-if="isEmpty"
+      class="flex h-32 items-center justify-center rounded-lg border border-dashed border-bg-tertiary"
+    >
+      <p class="text-text-muted">No similar songs found</p>
+    </div>
+
+    <!-- Songs grid -->
+    <div
+      v-else
+      class="flex gap-3 overflow-x-auto pb-2 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-bg-tertiary"
+    >
+      <RecommendationCard
+        v-for="song in songs"
+        :key="song.id"
+        :song="song"
+        :is-playing="currentSongId === song.id"
+        show-reason
+        :reason="reasonsMap[song.id]"
+        @play="handlePlay"
+        @click="handleClick"
+      />
+    </div>
+  </section>
+</template>

--- a/frontend/src/components/recommendations/index.ts
+++ b/frontend/src/components/recommendations/index.ts
@@ -1,0 +1,4 @@
+export { default as RecommendationCard } from './RecommendationCard.vue'
+export { default as RecommendationSection } from './RecommendationSection.vue'
+export { default as SimilarSongs } from './SimilarSongs.vue'
+export { default as PersonalMixCard } from './PersonalMixCard.vue'

--- a/frontend/src/components/search/GlobalSearch.vue
+++ b/frontend/src/components/search/GlobalSearch.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+/**
+ * GlobalSearch Component
+ *
+ * This component should be included in the App.vue or main layout
+ * to provide global search functionality via Cmd+K (Mac) / Ctrl+K (Windows).
+ *
+ * The actual search modal is rendered via Teleport to body.
+ */
+
+import SearchModal from './SearchModal.vue'
+</script>
+
+<template>
+  <SearchModal />
+</template>

--- a/frontend/src/components/search/SearchModal.vue
+++ b/frontend/src/components/search/SearchModal.vue
@@ -1,0 +1,327 @@
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useRouter } from 'vue-router'
+import { useRecommendationsStore } from '@/stores/recommendations'
+import { usePlayerStore } from '@/stores/player'
+import { useUiStore } from '@/stores/ui'
+import type { Song, ArtistSearchResult, AlbumSearchResult, PlaylistSearchResult } from '@/types'
+import SearchResults from './SearchResults.vue'
+
+const router = useRouter()
+const recommendationsStore = useRecommendationsStore()
+const playerStore = usePlayerStore()
+const uiStore = useUiStore()
+
+const { searchResults, isSearching, searchError } = storeToRefs(recommendationsStore)
+const { isSearchOpen } = storeToRefs(uiStore)
+
+const searchInput = ref<HTMLInputElement | null>(null)
+const searchResultsRef = ref<InstanceType<typeof SearchResults> | null>(null)
+const query = ref('')
+const selectedIndex = ref(-1)
+let debounceTimer: ReturnType<typeof setTimeout> | null = null
+
+const itemCount = computed(() => {
+  if (!searchResults.value) return 0
+  return (
+    (searchResults.value.songs?.length ?? 0) +
+    (searchResults.value.artists?.length ?? 0) +
+    (searchResults.value.albums?.length ?? 0) +
+    (searchResults.value.playlists?.length ?? 0)
+  )
+})
+
+// Watch for modal open/close
+watch(isSearchOpen, async (open) => {
+  if (open) {
+    await nextTick()
+    searchInput.value?.focus()
+  } else {
+    query.value = ''
+    selectedIndex.value = -1
+    recommendationsStore.clearSearch()
+  }
+})
+
+// Debounced search
+watch(query, (newQuery) => {
+  selectedIndex.value = -1
+
+  if (debounceTimer) {
+    clearTimeout(debounceTimer)
+  }
+
+  if (!newQuery.trim()) {
+    recommendationsStore.clearSearch()
+    return
+  }
+
+  debounceTimer = setTimeout(async () => {
+    await recommendationsStore.search(newQuery.trim())
+  }, 300)
+})
+
+function close() {
+  uiStore.toggleSearch()
+}
+
+function handleOverlayClick() {
+  close()
+}
+
+function handleKeyDown(event: KeyboardEvent) {
+  switch (event.key) {
+    case 'Escape':
+      close()
+      break
+    case 'ArrowDown':
+      event.preventDefault()
+      if (itemCount.value > 0) {
+        selectedIndex.value = (selectedIndex.value + 1) % itemCount.value
+      }
+      break
+    case 'ArrowUp':
+      event.preventDefault()
+      if (itemCount.value > 0) {
+        selectedIndex.value = selectedIndex.value <= 0 ? itemCount.value - 1 : selectedIndex.value - 1
+      }
+      break
+    case 'Enter':
+      event.preventDefault()
+      handleEnter()
+      break
+  }
+}
+
+function handleEnter() {
+  if (selectedIndex.value < 0 || !searchResults.value) return
+
+  const flatItems = getFlatItems()
+  const item = flatItems[selectedIndex.value]
+  if (!item) return
+
+  switch (item.type) {
+    case 'song':
+      handleSelectSong(item.data as Song)
+      break
+    case 'artist':
+      handleSelectArtist(item.data as ArtistSearchResult)
+      break
+    case 'album':
+      handleSelectAlbum(item.data as AlbumSearchResult)
+      break
+    case 'playlist':
+      handleSelectPlaylist(item.data as PlaylistSearchResult)
+      break
+  }
+}
+
+function getFlatItems() {
+  const items: Array<{
+    type: 'song' | 'artist' | 'album' | 'playlist'
+    data: Song | ArtistSearchResult | AlbumSearchResult | PlaylistSearchResult
+  }> = []
+
+  if (searchResults.value?.songs) {
+    for (const song of searchResults.value.songs) {
+      items.push({ type: 'song', data: song })
+    }
+  }
+  if (searchResults.value?.artists) {
+    for (const artist of searchResults.value.artists) {
+      items.push({ type: 'artist', data: artist })
+    }
+  }
+  if (searchResults.value?.albums) {
+    for (const album of searchResults.value.albums) {
+      items.push({ type: 'album', data: album })
+    }
+  }
+  if (searchResults.value?.playlists) {
+    for (const playlist of searchResults.value.playlists) {
+      items.push({ type: 'playlist', data: playlist })
+    }
+  }
+
+  return items
+}
+
+function handleSelectSong(song: Song) {
+  playerStore.play(song)
+  close()
+}
+
+function handlePlaySong(song: Song) {
+  playerStore.play(song)
+  close()
+}
+
+function handleSelectArtist(artist: ArtistSearchResult) {
+  // Navigate to library with artist filter
+  router.push({ name: 'library', query: { artist: artist.name } })
+  close()
+}
+
+function handleSelectAlbum(album: AlbumSearchResult) {
+  // Navigate to library with album filter
+  router.push({ name: 'library', query: { album: album.name } })
+  close()
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function handleSelectPlaylist(playlist: PlaylistSearchResult) {
+  // For now, just close - playlists page not yet implemented
+  close()
+}
+
+// Global keyboard listener for Cmd+K
+function handleGlobalKeyDown(event: KeyboardEvent) {
+  if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+    event.preventDefault()
+    uiStore.toggleSearch()
+  }
+}
+
+onMounted(() => {
+  window.addEventListener('keydown', handleGlobalKeyDown)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleGlobalKeyDown)
+  if (debounceTimer) {
+    clearTimeout(debounceTimer)
+  }
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition-opacity duration-fast"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition-opacity duration-fast"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="isSearchOpen"
+        class="fixed inset-0 z-50 flex items-start justify-center pt-20"
+        @keydown="handleKeyDown"
+      >
+        <!-- Overlay -->
+        <div
+          class="absolute inset-0 bg-black/50 backdrop-blur-sm"
+          @click="handleOverlayClick"
+        />
+
+        <!-- Search Modal -->
+        <Transition
+          enter-active-class="transition-all duration-fast"
+          enter-from-class="opacity-0 scale-95 -translate-y-4"
+          enter-to-class="opacity-100 scale-100 translate-y-0"
+          leave-active-class="transition-all duration-fast"
+          leave-from-class="opacity-100 scale-100 translate-y-0"
+          leave-to-class="opacity-0 scale-95 -translate-y-4"
+        >
+          <div
+            v-if="isSearchOpen"
+            class="relative w-full max-w-xl rounded-xl bg-bg-primary shadow-2xl"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Search"
+          >
+            <!-- Search input -->
+            <div class="flex items-center border-b border-bg-tertiary px-4">
+              <svg
+                class="h-5 w-5 text-text-muted"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                stroke-width="1.5"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+                />
+              </svg>
+              <input
+                ref="searchInput"
+                v-model="query"
+                type="text"
+                class="flex-1 bg-transparent px-3 py-4 text-text-primary placeholder-text-muted focus:outline-none"
+                placeholder="Search songs, artists, albums..."
+                aria-label="Search"
+              >
+              <button
+                type="button"
+                class="rounded p-1 text-text-muted hover:bg-bg-secondary hover:text-text-primary transition-colors"
+                aria-label="Close search"
+                @click="close"
+              >
+                <svg
+                  class="h-5 w-5"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            </div>
+
+            <!-- Results -->
+            <SearchResults
+              v-if="query.trim()"
+              ref="searchResultsRef"
+              :results="searchResults"
+              :is-loading="isSearching"
+              :selected-index="selectedIndex"
+              @select-song="handleSelectSong"
+              @play-song="handlePlaySong"
+              @select-artist="handleSelectArtist"
+              @select-album="handleSelectAlbum"
+              @select-playlist="handleSelectPlaylist"
+            />
+
+            <!-- Error state -->
+            <div
+              v-if="searchError && query.trim()"
+              class="p-4 text-center text-accent-error"
+            >
+              {{ searchError }}
+            </div>
+
+            <!-- Keyboard hints -->
+            <div class="flex items-center justify-between border-t border-bg-tertiary px-4 py-2 text-caption text-text-muted">
+              <div class="flex items-center gap-4">
+                <span class="flex items-center gap-1">
+                  <kbd class="rounded border border-bg-tertiary bg-bg-secondary px-1.5 py-0.5">↑</kbd>
+                  <kbd class="rounded border border-bg-tertiary bg-bg-secondary px-1.5 py-0.5">↓</kbd>
+                  to navigate
+                </span>
+                <span class="flex items-center gap-1">
+                  <kbd class="rounded border border-bg-tertiary bg-bg-secondary px-1.5 py-0.5">Enter</kbd>
+                  to select
+                </span>
+              </div>
+              <span class="flex items-center gap-1">
+                <kbd class="rounded border border-bg-tertiary bg-bg-secondary px-1.5 py-0.5">Esc</kbd>
+                to close
+              </span>
+            </div>
+          </div>
+        </Transition>
+      </div>
+    </Transition>
+  </Teleport>
+</template>

--- a/frontend/src/components/search/SearchResultItem.vue
+++ b/frontend/src/components/search/SearchResultItem.vue
@@ -1,0 +1,175 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { Song, ArtistSearchResult, AlbumSearchResult, PlaylistSearchResult } from '@/types'
+import { formatDuration, getCoverUrl } from '@/services/songs'
+
+export type ResultType = 'song' | 'artist' | 'album' | 'playlist'
+
+export interface SearchResultItemProps {
+  type: ResultType
+  song?: Song
+  artist?: ArtistSearchResult
+  album?: AlbumSearchResult
+  playlist?: PlaylistSearchResult
+  isSelected?: boolean
+}
+
+const props = withDefaults(defineProps<SearchResultItemProps>(), {
+  song: undefined,
+  artist: undefined,
+  album: undefined,
+  playlist: undefined,
+  isSelected: false,
+})
+
+const emit = defineEmits<{
+  select: []
+  play: []
+}>()
+
+const title = computed(() => {
+  if (props.type === 'song' && props.song) return props.song.title
+  if (props.type === 'artist' && props.artist) return props.artist.name
+  if (props.type === 'album' && props.album) return props.album.name
+  if (props.type === 'playlist' && props.playlist) return props.playlist.name
+  return ''
+})
+
+const subtitle = computed(() => {
+  if (props.type === 'song' && props.song) return props.song.artist || 'Unknown Artist'
+  if (props.type === 'artist' && props.artist) return `${props.artist.song_count} songs`
+  if (props.type === 'album' && props.album)
+    return props.album.artist
+      ? `${props.album.artist} · ${props.album.song_count} songs`
+      : `${props.album.song_count} songs`
+  if (props.type === 'playlist' && props.playlist) return `${props.playlist.song_count} songs`
+  return ''
+})
+
+const duration = computed(() => {
+  if (props.type === 'song' && props.song) return formatDuration(props.song.duration_seconds)
+  return ''
+})
+
+const coverUrl = computed(() => {
+  if (props.type === 'song' && props.song?.cover_art_path) {
+    return getCoverUrl(props.song.id)
+  }
+  return null
+})
+
+const iconPath = computed(() => {
+  switch (props.type) {
+    case 'song':
+      return 'M9 9l10.5-3m0 6.553v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 11-.99-3.467l2.31-.66a2.25 2.25 0 001.632-2.163zm0 0V2.25L9 5.25v10.303m0 0v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 01-.99-3.467l2.31-.66A2.25 2.25 0 009 15.553z'
+    case 'artist':
+      return 'M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z'
+    case 'album':
+      return 'M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 010 3.75H5.625a1.875 1.875 0 010-3.75z'
+    case 'playlist':
+      return 'M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5'
+    default:
+      return ''
+  }
+})
+
+function handleClick() {
+  emit('select')
+}
+
+function handlePlay(event: MouseEvent) {
+  event.stopPropagation()
+  emit('play')
+}
+</script>
+
+<template>
+  <div
+    :class="[
+      'flex items-center gap-3 px-3 py-2 cursor-pointer rounded-lg transition-colors',
+      isSelected ? 'bg-accent-primary/10' : 'hover:bg-bg-secondary',
+    ]"
+    role="option"
+    :aria-selected="isSelected"
+    @click="handleClick"
+  >
+    <!-- Cover/Icon -->
+    <div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded bg-bg-tertiary overflow-hidden">
+      <img
+        v-if="coverUrl"
+        :src="coverUrl"
+        :alt="title"
+        class="h-full w-full object-cover"
+      >
+      <svg
+        v-else
+        class="h-5 w-5 text-text-muted"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        stroke-width="1.5"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          :d="iconPath"
+        />
+      </svg>
+    </div>
+
+    <!-- Info -->
+    <div class="flex-1 min-w-0">
+      <p class="truncate text-small font-medium text-text-primary">{{ title }}</p>
+      <p class="truncate text-caption text-text-secondary">{{ subtitle }}</p>
+    </div>
+
+    <!-- Duration (for songs) -->
+    <span
+      v-if="duration"
+      class="text-caption text-text-muted"
+    >
+      {{ duration }}
+    </span>
+
+    <!-- Play button (for songs) -->
+    <button
+      v-if="type === 'song'"
+      type="button"
+      class="flex h-8 w-8 items-center justify-center rounded-full bg-accent-primary text-white opacity-0 transition-opacity group-hover:opacity-100"
+      :class="{ '!opacity-100': isSelected }"
+      aria-label="Play"
+      @click="handlePlay"
+    >
+      <svg
+        class="h-4 w-4 translate-x-0.5"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+      >
+        <path
+          fill-rule="evenodd"
+          d="M4.5 5.653c0-1.426 1.529-2.33 2.779-1.643l11.54 6.348c1.295.712 1.295 2.573 0 3.285L7.28 19.991c-1.25.687-2.779-.217-2.779-1.643V5.653z"
+          clip-rule="evenodd"
+        />
+      </svg>
+    </button>
+
+    <!-- Arrow (for navigation items) -->
+    <svg
+      v-else
+      class="h-4 w-4 text-text-muted"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      stroke-width="2"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M8.25 4.5l7.5 7.5-7.5 7.5"
+      />
+    </svg>
+  </div>
+</template>

--- a/frontend/src/components/search/SearchResults.vue
+++ b/frontend/src/components/search/SearchResults.vue
@@ -1,0 +1,194 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { Song, SearchResponse, ArtistSearchResult, AlbumSearchResult, PlaylistSearchResult } from '@/types'
+import SearchResultItem from './SearchResultItem.vue'
+import { Loader } from '@/components/ui'
+
+export interface SearchResultsProps {
+  results: SearchResponse | null
+  isLoading?: boolean
+  selectedIndex?: number
+}
+
+const props = withDefaults(defineProps<SearchResultsProps>(), {
+  isLoading: false,
+  selectedIndex: -1,
+})
+
+const emit = defineEmits<{
+  selectSong: [song: Song]
+  playSong: [song: Song]
+  selectArtist: [artist: ArtistSearchResult]
+  selectAlbum: [album: AlbumSearchResult]
+  selectPlaylist: [playlist: PlaylistSearchResult]
+}>()
+
+const hasSongs = computed(() => props.results?.songs && props.results.songs.length > 0)
+const hasArtists = computed(() => props.results?.artists && props.results.artists.length > 0)
+const hasAlbums = computed(() => props.results?.albums && props.results.albums.length > 0)
+const hasPlaylists = computed(() => props.results?.playlists && props.results.playlists.length > 0)
+const hasResults = computed(() => hasSongs.value || hasArtists.value || hasAlbums.value || hasPlaylists.value)
+const isEmpty = computed(() => props.results && !hasResults.value && !props.isLoading)
+
+// Build a flat list of all items for keyboard navigation
+const flatItems = computed(() => {
+  const items: Array<{
+    type: 'song' | 'artist' | 'album' | 'playlist'
+    data: Song | ArtistSearchResult | AlbumSearchResult | PlaylistSearchResult
+  }> = []
+
+  if (props.results?.songs) {
+    for (const song of props.results.songs) {
+      items.push({ type: 'song', data: song })
+    }
+  }
+  if (props.results?.artists) {
+    for (const artist of props.results.artists) {
+      items.push({ type: 'artist', data: artist })
+    }
+  }
+  if (props.results?.albums) {
+    for (const album of props.results.albums) {
+      items.push({ type: 'album', data: album })
+    }
+  }
+  if (props.results?.playlists) {
+    for (const playlist of props.results.playlists) {
+      items.push({ type: 'playlist', data: playlist })
+    }
+  }
+
+  return items
+})
+
+// Track which flat index corresponds to which item
+function getItemIndex(type: string, index: number): number {
+  let offset = 0
+  if (type === 'song') return index
+  offset += props.results?.songs?.length ?? 0
+  if (type === 'artist') return offset + index
+  offset += props.results?.artists?.length ?? 0
+  if (type === 'album') return offset + index
+  offset += props.results?.albums?.length ?? 0
+  if (type === 'playlist') return offset + index
+  return -1
+}
+
+function handleSelectSong(song: Song) {
+  emit('selectSong', song)
+}
+
+function handlePlaySong(song: Song) {
+  emit('playSong', song)
+}
+
+function handleSelectArtist(artist: ArtistSearchResult) {
+  emit('selectArtist', artist)
+}
+
+function handleSelectAlbum(album: AlbumSearchResult) {
+  emit('selectAlbum', album)
+}
+
+function handleSelectPlaylist(playlist: PlaylistSearchResult) {
+  emit('selectPlaylist', playlist)
+}
+
+// Expose flatItems and length for parent component navigation
+defineExpose({
+  flatItems,
+  itemCount: computed(() => flatItems.value.length),
+})
+</script>
+
+<template>
+  <div class="max-h-96 overflow-y-auto">
+    <!-- Loading state -->
+    <div
+      v-if="isLoading"
+      class="flex h-32 items-center justify-center"
+    >
+      <Loader size="md" />
+    </div>
+
+    <!-- Empty state -->
+    <div
+      v-else-if="isEmpty"
+      class="flex h-32 items-center justify-center"
+    >
+      <p class="text-text-muted">No results found for "{{ results?.query }}"</p>
+    </div>
+
+    <!-- Results -->
+    <template v-else-if="hasResults">
+      <!-- Songs -->
+      <section v-if="hasSongs">
+        <h3 class="px-3 py-2 text-caption font-semibold uppercase tracking-wide text-text-muted">
+          Songs
+        </h3>
+        <div role="listbox">
+          <SearchResultItem
+            v-for="(song, index) in results!.songs"
+            :key="song.id"
+            type="song"
+            :song="song"
+            :is-selected="selectedIndex === getItemIndex('song', index)"
+            @select="handleSelectSong(song)"
+            @play="handlePlaySong(song)"
+          />
+        </div>
+      </section>
+
+      <!-- Artists -->
+      <section v-if="hasArtists">
+        <h3 class="px-3 py-2 text-caption font-semibold uppercase tracking-wide text-text-muted">
+          Artists
+        </h3>
+        <div role="listbox">
+          <SearchResultItem
+            v-for="(artist, index) in results!.artists"
+            :key="artist.name"
+            type="artist"
+            :artist="artist"
+            :is-selected="selectedIndex === getItemIndex('artist', index)"
+            @select="handleSelectArtist(artist)"
+          />
+        </div>
+      </section>
+
+      <!-- Albums -->
+      <section v-if="hasAlbums">
+        <h3 class="px-3 py-2 text-caption font-semibold uppercase tracking-wide text-text-muted">
+          Albums
+        </h3>
+        <div role="listbox">
+          <SearchResultItem
+            v-for="(album, index) in results!.albums"
+            :key="`${album.name}-${album.artist}`"
+            type="album"
+            :album="album"
+            :is-selected="selectedIndex === getItemIndex('album', index)"
+            @select="handleSelectAlbum(album)"
+          />
+        </div>
+      </section>
+
+      <!-- Playlists -->
+      <section v-if="hasPlaylists">
+        <h3 class="px-3 py-2 text-caption font-semibold uppercase tracking-wide text-text-muted">
+          Playlists
+        </h3>
+        <div role="listbox">
+          <SearchResultItem
+            v-for="(playlist, index) in results!.playlists"
+            :key="playlist.id"
+            type="playlist"
+            :playlist="playlist"
+            :is-selected="selectedIndex === getItemIndex('playlist', index)"
+            @select="handleSelectPlaylist(playlist)"
+          />
+        </div>
+      </section>
+    </template>
+  </div>
+</template>

--- a/frontend/src/components/search/index.ts
+++ b/frontend/src/components/search/index.ts
@@ -1,0 +1,4 @@
+export { default as GlobalSearch } from './GlobalSearch.vue'
+export { default as SearchModal } from './SearchModal.vue'
+export { default as SearchResults } from './SearchResults.vue'
+export { default as SearchResultItem } from './SearchResultItem.vue'

--- a/frontend/src/services/recommendations.ts
+++ b/frontend/src/services/recommendations.ts
@@ -1,0 +1,70 @@
+/**
+ * Recommendations Service
+ *
+ * API client for recommendations, similar songs, and global search endpoints.
+ */
+
+import { apiService } from './api'
+import type {
+  DiscoverResponse,
+  SimilarSongsResponse,
+  PersonalMixResponse,
+  SearchResponse,
+  MoodType,
+  SearchType,
+} from '@/types'
+
+export interface MixParams {
+  mood?: MoodType
+  duration_minutes?: number
+}
+
+export const recommendationsService = {
+  /**
+   * Get discovery recommendations (home page sections)
+   */
+  async getDiscover(limit: number = 10): Promise<DiscoverResponse> {
+    const response = await apiService.get<DiscoverResponse>('/recommendations/discover', {
+      limit,
+    })
+    return response.data
+  },
+
+  /**
+   * Get songs similar to a specific song
+   */
+  async getSimilarSongs(songId: string, limit: number = 10): Promise<SimilarSongsResponse> {
+    const response = await apiService.get<SimilarSongsResponse>(
+      `/recommendations/similar/${songId}`,
+      { limit }
+    )
+    return response.data
+  },
+
+  /**
+   * Generate a personal mix
+   */
+  async getPersonalMix(params: MixParams = {}): Promise<PersonalMixResponse> {
+    const response = await apiService.get<PersonalMixResponse>('/recommendations/mix', {
+      mood: params.mood,
+      duration_minutes: params.duration_minutes ?? 60,
+    })
+    return response.data
+  },
+
+  /**
+   * Global search across songs, artists, albums, and playlists
+   */
+  async search(
+    query: string,
+    type: SearchType = 'all',
+    limit: number = 10
+  ): Promise<SearchResponse> {
+    const response = await apiService.get<SearchResponse>('/search', {
+      q: query,
+      type,
+      limit,
+    })
+    return response.data
+  },
+}

--- a/frontend/src/stores/recommendations.ts
+++ b/frontend/src/stores/recommendations.ts
@@ -1,0 +1,275 @@
+/**
+ * Recommendations Store (Pinia)
+ *
+ * Manages the recommendations state including:
+ * - Discovery sections (home page)
+ * - Similar songs for a track
+ * - Personal mix generation
+ * - Global search results
+ */
+
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import type {
+  Song,
+  DiscoverSection,
+  SimilarSongItem,
+  SearchResponse,
+  MoodType,
+  SearchType,
+} from '@/types'
+import { recommendationsService, type MixParams } from '@/services/recommendations'
+
+export const useRecommendationsStore = defineStore('recommendations', () => {
+  // State - Discovery
+  const discoverSections = ref<DiscoverSection[]>([])
+  const isLoadingDiscover = ref(false)
+  const discoverError = ref<string | null>(null)
+
+  // State - Similar songs (keyed by songId)
+  const similarSongsMap = ref<Record<string, SimilarSongItem[]>>({})
+  const loadingSimilarFor = ref<string | null>(null)
+  const similarError = ref<string | null>(null)
+
+  // State - Personal mix
+  const personalMixSongs = ref<Song[]>([])
+  const personalMixDuration = ref(0)
+  const personalMixMood = ref<MoodType | null>(null)
+  const isLoadingMix = ref(false)
+  const mixError = ref<string | null>(null)
+
+  // State - Search
+  const searchQuery = ref('')
+  const searchResults = ref<SearchResponse | null>(null)
+  const isSearching = ref(false)
+  const searchError = ref<string | null>(null)
+
+  // Getters
+  const hasDiscoverSections = computed(() => discoverSections.value.length > 0)
+
+  const longTimeNoListen = computed(() =>
+    discoverSections.value.find((s) => s.type === 'long_time_no_listen')?.items ?? []
+  )
+
+  const basedOnFavorite = computed(() =>
+    discoverSections.value.find((s) => s.type === 'based_on_favorite')?.items ?? []
+  )
+
+  const hiddenGems = computed(() =>
+    discoverSections.value.find((s) => s.type === 'hidden_gems')?.items ?? []
+  )
+
+  const isLoading = computed(() =>
+    isLoadingDiscover.value ||
+    loadingSimilarFor.value !== null ||
+    isLoadingMix.value ||
+    isSearching.value
+  )
+
+  // Actions
+
+  /**
+   * Fetch discovery recommendations for the home page
+   */
+  async function fetchDiscover(limit: number = 10): Promise<void> {
+    isLoadingDiscover.value = true
+    discoverError.value = null
+
+    try {
+      const response = await recommendationsService.getDiscover(limit)
+      discoverSections.value = response.sections
+    } catch (e) {
+      discoverError.value = (e as { message: string }).message || 'Failed to load recommendations'
+      throw e
+    } finally {
+      isLoadingDiscover.value = false
+    }
+  }
+
+  /**
+   * Fetch similar songs for a specific song
+   */
+  async function fetchSimilar(songId: string, limit: number = 10): Promise<SimilarSongItem[]> {
+    // Return cached if available
+    if (similarSongsMap.value[songId]) {
+      return similarSongsMap.value[songId]
+    }
+
+    loadingSimilarFor.value = songId
+    similarError.value = null
+
+    try {
+      const response = await recommendationsService.getSimilarSongs(songId, limit)
+      similarSongsMap.value[songId] = response.items
+      return response.items
+    } catch (e) {
+      similarError.value = (e as { message: string }).message || 'Failed to load similar songs'
+      throw e
+    } finally {
+      loadingSimilarFor.value = null
+    }
+  }
+
+  /**
+   * Get cached similar songs for a song
+   */
+  function getSimilarSongs(songId: string): SimilarSongItem[] {
+    return similarSongsMap.value[songId] ?? []
+  }
+
+  /**
+   * Check if similar songs are loading for a specific song
+   */
+  function isLoadingSimilar(songId: string): boolean {
+    return loadingSimilarFor.value === songId
+  }
+
+  /**
+   * Generate a personal mix
+   */
+  async function generateMix(params: MixParams = {}): Promise<Song[]> {
+    isLoadingMix.value = true
+    mixError.value = null
+
+    try {
+      const response = await recommendationsService.getPersonalMix(params)
+      personalMixSongs.value = response.songs
+      personalMixDuration.value = response.total_duration_seconds
+      personalMixMood.value = response.mood
+      return response.songs
+    } catch (e) {
+      mixError.value = (e as { message: string }).message || 'Failed to generate mix'
+      throw e
+    } finally {
+      isLoadingMix.value = false
+    }
+  }
+
+  /**
+   * Perform global search
+   */
+  async function search(
+    query: string,
+    type: SearchType = 'all',
+    limit: number = 10
+  ): Promise<SearchResponse> {
+    if (!query.trim()) {
+      searchResults.value = null
+      searchQuery.value = ''
+      return { query: '', songs: [], artists: [], albums: [], playlists: [] }
+    }
+
+    searchQuery.value = query
+    isSearching.value = true
+    searchError.value = null
+
+    try {
+      const response = await recommendationsService.search(query, type, limit)
+      searchResults.value = response
+      return response
+    } catch (e) {
+      searchError.value = (e as { message: string }).message || 'Search failed'
+      throw e
+    } finally {
+      isSearching.value = false
+    }
+  }
+
+  /**
+   * Clear search results
+   */
+  function clearSearch(): void {
+    searchQuery.value = ''
+    searchResults.value = null
+    searchError.value = null
+  }
+
+  /**
+   * Clear personal mix
+   */
+  function clearMix(): void {
+    personalMixSongs.value = []
+    personalMixDuration.value = 0
+    personalMixMood.value = null
+  }
+
+  /**
+   * Clear cached similar songs for a specific song
+   */
+  function clearSimilarCache(songId?: string): void {
+    if (songId) {
+      delete similarSongsMap.value[songId]
+    } else {
+      similarSongsMap.value = {}
+    }
+  }
+
+  /**
+   * Clear all errors
+   */
+  function clearErrors(): void {
+    discoverError.value = null
+    similarError.value = null
+    mixError.value = null
+    searchError.value = null
+  }
+
+  /**
+   * Reset store to initial state
+   */
+  function reset(): void {
+    discoverSections.value = []
+    similarSongsMap.value = {}
+    personalMixSongs.value = []
+    personalMixDuration.value = 0
+    personalMixMood.value = null
+    searchQuery.value = ''
+    searchResults.value = null
+    clearErrors()
+  }
+
+  return {
+    // State - Discovery
+    discoverSections,
+    isLoadingDiscover,
+    discoverError,
+
+    // State - Similar songs
+    similarSongsMap,
+    loadingSimilarFor,
+    similarError,
+
+    // State - Personal mix
+    personalMixSongs,
+    personalMixDuration,
+    personalMixMood,
+    isLoadingMix,
+    mixError,
+
+    // State - Search
+    searchQuery,
+    searchResults,
+    isSearching,
+    searchError,
+
+    // Getters
+    hasDiscoverSections,
+    longTimeNoListen,
+    basedOnFavorite,
+    hiddenGems,
+    isLoading,
+
+    // Actions
+    fetchDiscover,
+    fetchSimilar,
+    getSimilarSongs,
+    isLoadingSimilar,
+    generateMix,
+    search,
+    clearSearch,
+    clearMix,
+    clearSimilarCache,
+    clearErrors,
+    reset,
+  }
+})

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -428,3 +428,65 @@ export interface RouteMeta extends Record<string, unknown> {
   requiresAuth?: boolean
   title?: string
 }
+
+// Recommendation types - matches backend schemas/recommendation.py
+
+export type MoodType = 'energetic' | 'calm' | 'focus'
+
+export type DiscoverSectionType = 'long_time_no_listen' | 'based_on_favorite' | 'hidden_gems'
+
+export type SearchType = 'all' | 'songs' | 'artists' | 'albums' | 'playlists'
+
+export interface SimilarSongItem {
+  song: Song
+  similarity_score: number
+  reasons: string[]
+}
+
+export interface SimilarSongsResponse {
+  source_song: Song
+  items: SimilarSongItem[]
+}
+
+export interface DiscoverSection {
+  type: DiscoverSectionType
+  title: string
+  items: Song[]
+}
+
+export interface DiscoverResponse {
+  sections: DiscoverSection[]
+}
+
+export interface PersonalMixResponse {
+  songs: Song[]
+  total_duration_seconds: number
+  mood: MoodType | null
+}
+
+export interface ArtistSearchResult {
+  name: string
+  song_count: number
+  songs: Song[]
+}
+
+export interface AlbumSearchResult {
+  name: string
+  artist: string | null
+  song_count: number
+  songs: Song[]
+}
+
+export interface PlaylistSearchResult {
+  id: string
+  name: string
+  song_count: number
+}
+
+export interface SearchResponse {
+  query: string
+  songs: Song[]
+  artists: ArtistSearchResult[]
+  albums: AlbumSearchResult[]
+  playlists: PlaylistSearchResult[]
+}


### PR DESCRIPTION
## Summary

This PR implements the frontend UI for recommendations and global search as described in Issue #17.

### Features Implemented

**Recommendations Components:**
- `recommendationsStore` (Pinia) - manages recommendations, similar songs, personal mix, and search state
- `recommendations` service - API client for `/recommendations/*` and `/search` endpoints
- `HomePage.vue` - updated with personalized recommendations sections:
  - "Давно не слушали" (Long time no listen)
  - "На основе любимого" (Based on favorite)
  - "Скрытые жемчужины" (Hidden gems)
- `RecommendationSection.vue` - horizontal scrolling section with navigation arrows
- `RecommendationCard.vue` - track card with cover art, play button, and playing indicator
- `SimilarSongs.vue` - component for displaying similar tracks on a song page
- `PersonalMixCard.vue` - personal mix generation with mood/duration settings modal

**Global Search (Cmd+K):**
- `GlobalSearch.vue` - main component included in App.vue
- `SearchModal.vue` - modal with:
  - Debounced search input (300ms)
  - Keyboard navigation (↑/↓ arrows, Enter to select, Escape to close)
  - Cmd+K / Ctrl+K global shortcut
- `SearchResults.vue` - categorized results (Songs, Artists, Albums, Playlists)
- `SearchResultItem.vue` - individual result item with type-specific icon and actions

**Type Definitions:**
- Added recommendation types to `types/index.ts`:
  - `MoodType`, `DiscoverSectionType`, `SearchType`
  - `SimilarSongItem`, `SimilarSongsResponse`
  - `DiscoverSection`, `DiscoverResponse`
  - `PersonalMixResponse`
  - `ArtistSearchResult`, `AlbumSearchResult`, `PlaylistSearchResult`, `SearchResponse`

### Keyboard Shortcuts

| Shortcut | Action |
|----------|--------|
| Cmd/Ctrl + K | Open global search |
| Escape | Close search |
| ↑/↓ | Navigate results |
| Enter | Select result |

### Test Coverage

- Added comprehensive unit tests for `recommendationsStore` (29 tests)
- Updated `App.spec.ts` to properly mock `useRouter` for the new `GlobalSearch` component

## Checklist

- [x] Home page shows recommendations sections
- [x] Cmd+K opens global search
- [x] Search finds tracks, artists, albums
- [x] Results are clickable (playback/navigation)
- [x] Similar songs component ready for song page integration
- [x] Personal mix generation with mood/duration settings
- [x] Unit tests passing
- [x] TypeScript type checks passing
- [x] ESLint checks passing

## Test Plan

1. Navigate to home page as authenticated user
2. Verify recommendation sections display with horizontal scroll
3. Press Cmd+K (Mac) or Ctrl+K (Windows) to open search
4. Type a query and verify debounced search
5. Use arrow keys to navigate and Enter to select
6. Click on songs to play them
7. Click on artists/albums to filter library
8. Click "Create Mix" on PersonalMixCard and configure mood/duration

Fixes Krol-X/NiceMusicLibrary#17

🤖 Generated with [Claude Code](https://claude.com/claude-code)